### PR TITLE
Added Show Cursor and Jpg, Bmp and Tiff formats support.

### DIFF
--- a/FinalShot/FinalShot.cs
+++ b/FinalShot/FinalShot.cs
@@ -411,12 +411,32 @@ namespace PluginScreenshot
         {
             try
             {
-                bitmap.Save(savePath, ImageFormat.Png);
+                ImageFormat format = GetImageFormat(savePath);
+                bitmap.Save(savePath, format);
                 Logger.Log("Custom screenshot saved to: " + savePath);
             }
             catch (Exception ex)
             {
                 Logger.Log("Error saving custom screenshot: " + ex.Message);
+            }
+        }
+
+        private ImageFormat GetImageFormat(string path)
+        {
+            string ext = Path.GetExtension(path).ToLowerInvariant();
+            switch (ext)
+            {
+                case ".jpg":
+                case ".jpeg":
+                    return ImageFormat.Jpeg;
+                case ".png":
+                    return ImageFormat.Png;
+                case ".bmp":
+                    return ImageFormat.Bmp;
+                case ".tiff":
+                    return ImageFormat.Tiff;
+                default:
+                    return ImageFormat.Png; // fallback
             }
         }
     }


### PR DESCRIPTION
Added `ShowCursor` option to the measure.

Enable Cursor display by setting `ShowCursor=1` on the measure. (It's disabled by default).


Added support for more image formats.
To save a screenshot on other formats simply add the right extension to the path:
```
SavePath=Path\to\MyScreenshot.png
SavePath=Path\to\MyScreenshot.jpg
SavePath=Path\to\MyScreenshot.bmp
SavePath=Path\to\MyScreenshot.tiff
```